### PR TITLE
fix typo (Github -> GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # incremental-indexing-fork-controller
 
-This is a stub repository that defines a [Github Action workflow](./.github/workflows/sync.yaml) that is used to sync https://github.com/sourcegraph/sourcegraph to https://github.com/sgtest/sourcegraph-incremental-indexing-fork on a regular basis.
+This is a stub repository that defines a [GitHub Action workflow](./.github/workflows/sync.yaml) that is used to sync https://github.com/sourcegraph/sourcegraph to https://github.com/sgtest/sourcegraph-incremental-indexing-fork on a regular basis.


### PR DESCRIPTION


[_Created by Sourcegraph batch change `sqs/github-case`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/github-case)